### PR TITLE
fix(core): migrate FileSerde to InputStream/OutputStream API for binary ION support

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 version=1.3.3-SNAPSHOT
-kestraVersion=1.3.13
+kestraVersion=1.3.19

--- a/src/test/java/io/kestra/plugin/mqtt/SuiteTest.java
+++ b/src/test/java/io/kestra/plugin/mqtt/SuiteTest.java
@@ -1,11 +1,8 @@
 package io.kestra.plugin.mqtt;
 
-import java.io.BufferedReader;
-import java.io.InputStreamReader;
-import java.net.URL;
+import java.io.BufferedInputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -80,9 +77,10 @@ class SuiteTest {
             .build();
         Subscribe.Output subscribeOutput = subscribe.run(runContext);
 
-        BufferedReader inputStream = new BufferedReader(new InputStreamReader(storageInterface.get(TenantService.MAIN_TENANT, null, subscribeOutput.getUri())));
-        List<Map<String, Object>> result = new ArrayList<>();
-        FileSerde.reader(inputStream, r -> result.add((Map<String, Object>) r));
+        List<Map<String, Object>> result;
+        try (var inputStream = new BufferedInputStream(storageInterface.get(TenantService.MAIN_TENANT, null, subscribeOutput.getUri()), FileSerde.BUFFER_SIZE)) {
+            result = FileSerde.readAll(inputStream, Map.class).map(m -> (Map<String, Object>) m).collectList().block();
+        }
 
         assertThat(result.size(), is(1));
 


### PR DESCRIPTION
Migrates the FileSerde reads and writes to byte streams so binary ION is not corrupted.